### PR TITLE
Extension improvements

### DIFF
--- a/src/checkpatchProvider.ts
+++ b/src/checkpatchProvider.ts
@@ -89,7 +89,7 @@ export default class CheckpatchProvider implements vscode.CodeActionProvider {
 	private parseCheckpatchLog(log: string, basePath: string): number {
 		const dictionary: { [fileUri: string]: vscode.Diagnostic[] } = {};
 
-		var re = /(WARNING|ERROR): ?(.+):(.+)?(?:\n|\r\n|)#\d+: FILE: (.*):(\d+):/g;
+		var re = /(WARNING|ERROR|CHECK): ?(.+):(.+)?(?:\n|\r\n|)#\d+: FILE: (.*):(\d+):/g;
 		var matches;
 		while (matches = re.exec(log)) {
 			let type = matches[2];

--- a/src/checkpatchProvider.ts
+++ b/src/checkpatchProvider.ts
@@ -128,6 +128,8 @@ export default class CheckpatchProvider implements vscode.CodeActionProvider {
 
 		let childProcess = cp.spawn(this.linterConfig.path, args, { shell: true });
 		if (childProcess.pid) {
+			// clean old diagostics. Prevents files with only one warning from being updated
+			this.diagnosticCollection.delete(textDocument.uri);
 			childProcess.stdout.on('data', (data: Buffer) => log += data);
 			childProcess.stdout.on('end', () => this.parseCheckpatchLog(log, ''));
 		} else {

--- a/src/checkpatchProvider.ts
+++ b/src/checkpatchProvider.ts
@@ -64,8 +64,7 @@ export default class CheckpatchProvider implements vscode.CodeActionProvider {
 
 		// testing given configuration:
 		var re = /total: \d* errors, \d* warnings, \d* lines checked/g;
-		let args = this.linterConfig.args.slice();
-		args.push('--no-tree - ');
+		var args = ['--no-tree'];
 		let childProcess = cp.spawnSync(this.linterConfig.path, args, { shell: true, input: ' ' });
 		if (childProcess.pid && re.test(childProcess.stdout.toString())) {
 			// all good


### PR DESCRIPTION
This PR adds two fixes:

1. Adding some arguments would make the `loadconfig` function to fail;
2. Files with only one problem would never be updated after fixing the problem.

Additional, it adds support to the `--strict` argument so that new messages can be displayed.